### PR TITLE
Optimize Real-Time mode

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -17,9 +17,9 @@ sudo docker compose up --build -d
 If simulator and api containers are exited start them:
 
 ```shell
-sudo docker container start simulator
-sudo docker container start src-api-1
-sudo docker container restart nginx
+docker container start simulator
+docker container start src-api-1
+docker container restart nginx
 ```
 
 # Usage

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -12,7 +12,6 @@ from routers.tasks import router as tasks_router
 from routers.auth import router as auth_router
 from routers.maps import router as maps_router
 from routers.offline_scenarios import router as offline_router
-from queues.images import queue
 from utils import create_admin, create_map
 
 @asynccontextmanager
@@ -56,10 +55,7 @@ app.include_router(offline_router, prefix='/api')
 async def main():
     config = Config(app=app,host=settings.host, port=settings.port, reload=settings.debug)
     server = Server(config=config)
-    await asyncio.gather(
-        server.serve(),
-        queue.consume_results()
-    )
+    await server.serve()
 
 
 

--- a/src/api/queues/images.py
+++ b/src/api/queues/images.py
@@ -8,23 +8,24 @@ from settings import settings
 from db.scenario_repository import ScenarioRepository
 from database import async_session
 from models.scenario import ScenarioStatus
+import aio_pika.exceptions
 
 class ImageQueue:
     def __init__(self, rabbitmq_url:str):
         self.rabbitmq_url = rabbitmq_url
 
-    def save_frame(self, scenario_id, step_num, image_bytes):
-        #file_name = settings.static_dir / "frames" / str(scenario_id) / f"{str(step_num)}.png"
-        file_name = settings.base_dir / f"{scenario_id}.png"
-        dir_name = os.path.dirname(file_name)
-
-        if not os.path.exists(dir_name):
-            os.makedirs(dir_name, exist_ok=True)
-
-        decoded_bytes = base64.b64decode(image_bytes)
-
-        with open(file_name, "wb+") as f:
-            f.write(decoded_bytes)
+    # def save_frame(self, scenario_id, step_num, image_bytes):
+    #     #file_name = settings.static_dir / "frames" / str(scenario_id) / f"{str(step_num)}.png"
+    #     file_name = settings.base_dir / f"{scenario_id}.png"
+    #     dir_name = os.path.dirname(file_name)
+    #
+    #     if not os.path.exists(dir_name):
+    #         os.makedirs(dir_name, exist_ok=True)
+    #
+    #     decoded_bytes = base64.b64decode(image_bytes)
+    #
+    #     with open(file_name, "wb+") as f:
+    #         f.write(decoded_bytes)
 
     def save_gif(self, scenario_id, gif_bytes):
         gif_path = settings.static_dir / "gifs" / f"{scenario_id}.gif"
@@ -39,29 +40,55 @@ class ImageQueue:
         with open(gif_path, "wb+") as f:
             f.write(decoded_bytes)
 
-    async def consume_results(self):
+    async def consume_results(self, scenario_id: int):
         connection = await aio_pika.connect_robust(self.rabbitmq_url)
         async with connection:
             channel = await connection.channel()
             queue = await channel.declare_queue('images_queue', durable=True)
 
-            async for message in queue:
+            last_relevant_message = None
+
+            while True:
+                try:
+                    message = await queue.get(timeout=0.1, no_ack=False)
+                except aio_pika.exceptions.QueueEmpty:
+                    break  # No more messages to check
+
                 async with message.process():
-                    message_body = json.loads(message.body.decode("utf-8"))  # Decode JSON
+                    try:
+                        message_body = json.loads(message.body.decode("utf-8"))
+                    except Exception:
+                        continue  # Skip if message is malformed
+
+                    if message_body['scenario_id'] != scenario_id:
+                        continue  # Skip other scenarios
+
                     status = message_body.get('status')
-                    scenario_id = message_body['scenario_id']
-                    if status == 'ACTIVE':
-                        step = message_body.get('step')
-                        self.save_frame(scenario_id, step, message_body['image_bytes'])
-                    else:
+
+                    if status == 'FINISHED':
                         async with async_session() as session:
                             scenario = await ScenarioRepository.get_scenario(session, scenario_id)
                             scenario.status = ScenarioStatus.FINISHED
                             await session.commit()
 
-                        self.save_gif(scenario_id, message_body['gif'])
+                        return {
+                            'alive': False,
+                            'gif': base64.b64decode(message_body['gif'])
+                        }
 
-                        print(message_body.get('reason'))
+                    elif status == 'ACTIVE':
+                        # Save the latest relevant frame
+                        last_relevant_message = message_body
+
+            # After consuming all messages, return the last relevant frame
+            if last_relevant_message:
+                return {
+                    'alive': True,
+                    'image': base64.b64decode(last_relevant_message['image_bytes'])
+                }
+
+            # No relevant message found
+            return None
 
 
 queue = ImageQueue(rabbitmq_url=settings.rabbitmq_url)


### PR DESCRIPTION
Currently the platform stores frames on disk, using the separate process slowing down the Real-Time mode.

The solution is to keep images in memory in the single runtime.

- [ ] Api service is a single process
- [ ] Return only the latest state to the user
- [ ] Finished scenario processing
- [ ] Well-tuned timeouts